### PR TITLE
Bug fix: modelChangedEvent Add triggered twice: on drag enter & drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ typings/
 # dotenv environment variables file
 .env
 
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-gojs",
-    "version": "1.4.1",
+    "version": "2.0.0",
     "description": "GoJS React integration",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
I only trigger modelChangedEvent event when it is part of a gojs transaction (to avoid duplicates on drag and drop).
Notifications are now delayed and occur when the transaction is committed
Breaking change: every change (using the gojs api) has to be done in a transaction.
Resolves #57 